### PR TITLE
fix: retract v0.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/traefik/genconf
 
-go 1.22
+go 1.19
+
+retract (
+	v0.5.1 // Retracts the previous version
+	v0.5.0 // Go version updated too early
+)


### PR DESCRIPTION
Revert #1

And retract v0.5.0

> To retract a version, a module author should add a retract directive to go.mod, then publish a new version containing that directive. The new version must be higher than other release or pre-release versions; that is, the @latest [version query](https://go.dev/ref/mod#version-queries) should resolve to the new version before retractions are considered.
> https://go.dev/ref/mod#go-mod-file-retract

a tag v0.5.1 should be created after the merge of this PR.