### PR TITLE
fix: retract v0.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.19
 retract (
 	v0.5.1 // Retracts the previous version
 	v0.5.0 // Go version updated too early
+	v0.4.0 // Use the wrong go version
 )


### PR DESCRIPTION
> predeclared any requires go1.18 or later (-lang was set to go1.17; check go.mod)